### PR TITLE
Delete resource definition if resource placement fails

### DIFF
--- a/driver.go
+++ b/driver.go
@@ -192,38 +192,9 @@ func (l *LinstorDriver) newParams(name string, options map[string]string) (*Lins
 	return params, nil
 }
 
-func (l *LinstorDriver) Create(req *volume.CreateRequest) (err error) {
-	params, err := l.newParams(req.Name, req.Options)
-	if err != nil {
-		return err
-	}
-	c, err := l.newClient()
-	if err != nil {
-		return err
-	}
+func (l *LinstorDriver) resourcesCreate(c *client.Client, req *volume.CreateRequest, params *LinstorParams) error {
 	ctx := context.Background()
-	err = c.ResourceDefinitions.Create(ctx, client.ResourceDefinitionCreate{
-		ResourceDefinition: client.ResourceDefinition{
-			Name: req.Name,
-			Props: map[string]string{
-				pluginFlagKey:           pluginFlagValue,
-				pluginFSTypeKey:         params.FS,
-				"FileSystem/MkfsParams": params.FSOpts,
-			},
-		},
-	})
-	if err != nil {
-		return err
-	}
-	defer func() {
-		if err != nil {
-			resources, err := c.Resources.GetAll(ctx, req.Name)
-			if err == nil && len(resources) == 0 {
-				c.ResourceDefinitions.Delete(ctx, req.Name)
-			}
-		}
-	}()
-	err = c.ResourceDefinitions.CreateVolumeDefinition(ctx, req.Name, client.VolumeDefinitionCreate{
+	err := c.ResourceDefinitions.CreateVolumeDefinition(ctx, req.Name, client.VolumeDefinitionCreate{
 		VolumeDefinition: client.VolumeDefinition{
 			SizeKib: params.SizeKiB,
 		},
@@ -250,6 +221,39 @@ func (l *LinstorDriver) Create(req *volume.CreateRequest) (err error) {
 		}
 	}
 	return nil
+}
+
+func (l *LinstorDriver) Create(req *volume.CreateRequest) error {
+	params, err := l.newParams(req.Name, req.Options)
+	if err != nil {
+		return err
+	}
+	c, err := l.newClient()
+	if err != nil {
+		return err
+	}
+	ctx := context.Background()
+	err = c.ResourceDefinitions.Create(ctx, client.ResourceDefinitionCreate{
+		ResourceDefinition: client.ResourceDefinition{
+			Name: req.Name,
+			Props: map[string]string{
+				pluginFlagKey:           pluginFlagValue,
+				pluginFSTypeKey:         params.FS,
+				"FileSystem/MkfsParams": params.FSOpts,
+			},
+		},
+	})
+	if err != nil {
+		return err
+	}
+	err = l.resourcesCreate(c, req, params)
+	if err != nil {
+		resources, err := c.Resources.GetAll(ctx, req.Name)
+		if err == nil && len(resources) == 0 {
+			c.ResourceDefinitions.Delete(ctx, req.Name)
+		}
+	}
+	return err
 }
 
 func (l *LinstorDriver) Get(req *volume.GetRequest) (*volume.GetResponse, error) {

--- a/driver.go
+++ b/driver.go
@@ -192,8 +192,7 @@ func (l *LinstorDriver) newParams(name string, options map[string]string) (*Lins
 	return params, nil
 }
 
-func (l *LinstorDriver) resourcesCreate(c *client.Client, req *volume.CreateRequest, params *LinstorParams) error {
-	ctx := context.Background()
+func (l *LinstorDriver) resourcesCreate(ctx context.Context, c *client.Client, req *volume.CreateRequest, params *LinstorParams) error {
 	err := c.ResourceDefinitions.CreateVolumeDefinition(ctx, req.Name, client.VolumeDefinitionCreate{
 		VolumeDefinition: client.VolumeDefinition{
 			SizeKib: params.SizeKiB,
@@ -246,7 +245,7 @@ func (l *LinstorDriver) Create(req *volume.CreateRequest) error {
 	if err != nil {
 		return err
 	}
-	err = l.resourcesCreate(c, req, params)
+	err = l.resourcesCreate(ctx, c, req, params)
 	if err != nil {
 		resources, err := c.Resources.GetAll(ctx, req.Name)
 		if err == nil && len(resources) == 0 {


### PR DESCRIPTION
On Create() in small clusters it is possible the autoplace fails in Linstor controller with the error "_Not enough available nodes_".  However Docker will see the volume as created when listing resource definitions. This leads to inconsistent state where the volume is mounted on a diskless node without a mirrored primary resource.

This PR addresses that issue by ensuring there is enough nodes in the given storage pool or any diskfull storage pool. Nodes must also have enough free capacity for the volume size to be counted.