### PR TITLE
Support for building on different architectures

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.10
+FROM alpine:3.13
 
 RUN set -x \
 	&& apk add --no-cache \

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,4 +1,4 @@
-FROM golang:1.12-alpine
+FROM golang:1.16-alpine
 
 COPY . /root/go/src/linstor-docker-volume
 WORKDIR /root/go/src/linstor-docker-volume

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,6 @@
 PLUGIN_NAME=lade/linstor
 PLUGIN_TAG=latest
+PLUGIN_ARCH=amd64
 
 all: clean docker rootfs create
 
@@ -9,20 +10,20 @@ clean:
 
 docker:
 	@echo "### docker build: builder image"
-	@docker build -q -t builder -f Dockerfile.dev .
+	@docker buildx build --platform linux/${PLUGIN_ARCH} -t builder -f Dockerfile.dev .
 	@echo "### extract linstor-docker-volume"
-	@docker create --name tmp builder
+	@docker create --platform linux/${PLUGIN_ARCH} --name tmp builder
 	@docker cp tmp:/go/bin/linstor-docker-volume .
 	@docker rm -vf tmp
 	@docker rmi builder
 	@echo "### docker build: rootfs image with linstor-docker-volume"
-	@docker build -q -t ${PLUGIN_NAME}:rootfs .
+	@docker buildx build --platform linux/${PLUGIN_ARCH} -t ${PLUGIN_NAME}:rootfs .
 	@rm ./linstor-docker-volume
 
 rootfs:
 	@echo "### create rootfs directory in ./plugin/rootfs"
 	@mkdir -p ./plugin/rootfs
-	@docker create --name tmp ${PLUGIN_NAME}:rootfs
+	@docker create --platform linux/${PLUGIN_ARCH} --name tmp ${PLUGIN_NAME}:rootfs
 	@docker export tmp | tar -x -C ./plugin/rootfs
 	@echo "### copy config.json to ./plugin/"
 	@cp config.json ./plugin/


### PR DESCRIPTION
Building for different architectures to address #10 requires setting up docker buildx which is no longer experimental since version 20.10.x. An example invocation to create and push an arm64 build is:

`make PLUGIN_ARCH=arm64 PLUGIN_TAG=arm64 push`