### PR TITLE
Allow to reuse mounted volumes fixes #13

### DIFF
--- a/driver.go
+++ b/driver.go
@@ -337,20 +337,23 @@ func (l *LinstorDriver) Mount(req *volume.MountRequest) (*volume.MountResponse, 
 		return nil, err
 	}
 	source := vol.DevicePath
-	inUse, err := l.mounter.DeviceOpened(source)
+	_, err = l.mounter.DeviceOpened(source)
 	if err != nil {
 		return nil, err
-	}
-	if inUse {
-		return nil, fmt.Errorf("unable to get exclusive open on %s", source)
 	}
 	target := l.realMountPath(req.Name)
 	if err = l.mounter.MakeDir(target); err != nil {
 		return nil, err
 	}
-	err = l.mounter.Mount(source, target, fstype, params.MountOpts)
+	needsMount, err := l.mounter.IsNotMountPoint(target)
 	if err != nil {
 		return nil, err
+	}
+	if needsMount {
+		err = l.mounter.Mount(source, target, fstype, params.MountOpts)
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	mnt := l.reportedMountPath(req.Name)


### PR DESCRIPTION
These changes were tested and allow reusing mounted volumes multiple times on the same host. However unmounting in use volumes during container exit is still an issue and will trigger an error:

```
Failed to umount volumes: error while unmounting volumes for container b3233e43e2: 
error unmounting volume test: VolumeDriver.Unmount: 
Message: 'Resource 'test' is still in use.'; Cause: 'Resource is mounted/in use.';
```

The first way I thought of fixing this is querying Docker API to see if other containers are still using the same volume. The Docker volume plugins docs suggest another solution:

"`Mount` is called once per container start. If the same `volume_name` is requested more than once, the plugin may need to keep track of each new mount request and provision at the first mount request and deprovision at the last corresponding unmount request."

This would require some storage of plugin internal state perhaps in a local file on the host.